### PR TITLE
Do not expect much order in the objects of the file

### DIFF
--- a/eventio/simtel/objects.py
+++ b/eventio/simtel/objects.py
@@ -1239,7 +1239,7 @@ class CameraMonitoring(EventIOObject):
         )
 
     def parse(self):
-        assert_exact_version(self, supported_version=0)
+        assert_version_in(self, supported_versions=(0, 1))
         self.seek(0)
         byte_stream = BytesIO(self.read())
 
@@ -1251,13 +1251,13 @@ class CameraMonitoring(EventIOObject):
         moni_time = read_time(byte_stream)
 
         #  Dimensions of various things
-        # version 0
-        ns, np, nd, ng = read_from(byte_stream, '<hhhh')
-        # in version 1 this uses crazy 32bit ints
-        # ns = read_utf8_like_signed_int(byte_stream)
-        # np = read_utf8_like_signed_int(byte_stream)
-        # nd = read_utf8_like_signed_int(byte_stream)
-        # ng = read_utf8_like_signed_int(byte_stream)
+        if self.header.version == 0:
+            ns, np, nd, ng = read_from(byte_stream, '<hhhh')
+        else:  # version == 1
+            ns = read_utf8_like_signed_int(byte_stream)
+            np = read_utf8_like_signed_int(byte_stream)
+            nd = read_utf8_like_signed_int(byte_stream)
+            ng = read_utf8_like_signed_int(byte_stream)
 
         result = {
             'telescope_id': self.telescope_id,

--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -75,7 +75,7 @@ class SimTelFile(EventIOFile):
         self.current_mc_shower = None
         self.current_mc_event = None
         self.current_photoelectron_sum = None
-        self.current_photoelectrons = None
+        self.current_photoelectrons = {}
         self.current_array_event = None
 
         # read the header:
@@ -196,11 +196,9 @@ class SimTelFile(EventIOFile):
                 'telescope_events': self.current_array_event['telescope_events'],
                 'tracking_positions': self.current_array_event['tracking_positions'],
                 'trigger_information': self.current_array_event['trigger_information'],
+                'photoelectron_sums': self.current_photoelectron_sum,
+                'photoelectrons': self.current_photoelectrons,
             }
-            if self.current_photoelectron_sum:
-                event_data['photoelectron_sums'] = self.current_photoelectron_sum
-            if self.current_photoelectrons:
-                event_data['photoelectrons'] = self.current_photoelectrons
 
             event_data['camera_monitorings'] = {
                 telescope_id: copy(self.camera_monitorings[telescope_id])

--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -6,7 +6,6 @@ import re
 from copy import copy
 from collections import defaultdict
 import logging
-import warnings
 from ..base import EventIOFile
 from ..exceptions import check_type
 from .. import iact
@@ -85,6 +84,7 @@ class SimTelFile(EventIOFile):
             self.next_low_level()
 
     def __iter__(self):
+        self.__init__(self.path, self.allowed_telescopes)
         return self.iter_array_events()
 
     def next_low_level(self):

--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -78,6 +78,12 @@ class SimTelFile(EventIOFile):
         self.current_photoelectrons = None
         self.current_array_event = None
 
+        # read the header:
+        # assumption: the header is done when
+        # self.current_mc_shower is not None anymore
+        while self.current_mc_shower is None:
+            self.next_low_level()
+
     def __iter__(self):
         return self.iter_array_events()
 
@@ -190,9 +196,12 @@ class SimTelFile(EventIOFile):
                 'telescope_events': self.current_array_event['telescope_events'],
                 'tracking_positions': self.current_array_event['tracking_positions'],
                 'trigger_information': self.current_array_event['trigger_information'],
-                'photoelectron_sums': self.current_photoelectron_sum,
-                'photoelectrons': self.current_photoelectrons,
             }
+            if self.current_photoelectron_sum:
+                event_data['photoelectron_sums'] = self.current_photoelectron_sum
+            if self.current_photoelectrons:
+                event_data['photoelectrons'] = self.current_photoelectrons
+
             event_data['camera_monitorings'] = {
                 telescope_id: copy(self.camera_monitorings[telescope_id])
                 for telescope_id in self.current_array_event['telescope_events'].keys()

--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -84,7 +84,6 @@ class SimTelFile(EventIOFile):
             self.next_low_level()
 
     def __iter__(self):
-        self.__init__(self.path, self.allowed_telescopes)
         return self.iter_array_events()
 
     def next_low_level(self):

--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -140,6 +140,26 @@ class SimTelFile(EventIOFile):
                 'at the moment: {}'.format(o)
             )
 
+    def iter_mc_events(self):
+        while True:
+            try:
+                next_event = self.try_build_mc_event()
+            except StopIteration:
+                break
+            if next_event is not None:
+                yield next_event
+
+    def try_build_mc_event(self):
+        self.next_low_level()
+        if self.current_mc_event:
+            event_data = {
+                'event_id': self.current_mc_event_id,
+                'mc_shower': self.current_mc_shower,
+                'mc_event': self.current_mc_event,
+            }
+            self.current_mc_event = None
+            return event_data
+
     def iter_array_events(self):
         while True:
             try:

--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -83,6 +83,8 @@ class SimTelFile(EventIOFile):
         while self.current_mc_shower is None:
             self.next_low_level()
 
+        self._first_event_byte = self.tell()
+
     def __iter__(self):
         return self.iter_array_events()
 
@@ -146,6 +148,7 @@ class SimTelFile(EventIOFile):
             )
 
     def iter_mc_events(self):
+        self._next_header_pos = self._first_event_byte
         while True:
             try:
                 next_event = self.try_build_mc_event()
@@ -166,6 +169,7 @@ class SimTelFile(EventIOFile):
             return event_data
 
     def iter_array_events(self):
+        self._next_header_pos = self._first_event_byte
         while True:
             try:
                 next_event = self.try_build_event()

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ with open('README.rst') as f:
 
 setup(
     name='eventio',
-    version='0.15.0',
+    version='0.16.0',
     description='Python read-only implementation of the EventIO file format',
     long_description=long_description,
     url='https://github.com/fact-project/pyeventio',


### PR DESCRIPTION
This should show the same features as  e.g. #138 but it does not expect any particular order in the objects anymore .. at least not so much order as we expected in the master.

This fixes #132, #135 and #137.

The test files needed to show this are in total 60MB! I was unable to make them smaller :-(

The tests showing that this branch fixes the upper issues are:
```python
from collections import defaultdict


# GH: 137
def test_simtel_file_can_read_file_with_strange_structure():
    from eventio import SimTelFile
    path = 'testfile_eventio_issue_137.simtel.gz'
    for event in SimTelFile(path):
        pass
    assert event


# GH: 135
def test_file_really_had_cam_orga_v2():
    from eventio import EventIOFile
    from eventio.simtel.objects import CameraOrganization
    path = 'has_CameraOrganization_v2.simtel.gz'
    cam_orga = []
    for o in EventIOFile(path):
        if isinstance(o, CameraOrganization) and o.header.version == 2:
            cam_orga.append(o)
    assert cam_orga


# GH: 135
def test_SimTelFile_can_read_this_file():
    from eventio import SimTelFile
    path = 'has_CameraOrganization_v2.simtel.gz'
    f = SimTelFile(path)
    assert f.header


# GH: 132
def test_SimTelFile_can_read_multiple_runs_from_file():
    path = 'run1011_merged.dst0.simtel.gz'
    from eventio import SimTelFile
    events_by_run = defaultdict(int)
    f = SimTelFile(path)
    for e in f:
        events_by_run[f.header['run']] += 1

    assert events_by_run[10] == 301
    assert events_by_run[11] == 315
```
