### PR TITLE
Fix some La Palma files not being read.

### DIFF
--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -109,7 +109,6 @@ class SimTelFile(EventIOFile):
             self.mc_run_headers.append(o.parse())
         elif isinstance(o, iact.InputCard):
             self.corsika_inputcards.append(o.parse())
-            # o = next(self)
         elif isinstance(o, telescope_descriptions_types):
             key = camel_to_snake(o.__class__.__name__)
             self.telescope_descriptions[o.telescope_id][key] = o.parse()

--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -109,7 +109,7 @@ class SimTelFile(EventIOFile):
             self.mc_run_headers.append(o.parse())
         elif isinstance(o, iact.InputCard):
             self.corsika_inputcards.append(o.parse())
-            o = next(self)
+            # o = next(self)
         elif isinstance(o, telescope_descriptions_types):
             key = camel_to_snake(o.__class__.__name__)
             self.telescope_descriptions[o.telescope_id][key] = o.parse()

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ with open('README.rst') as f:
 
 setup(
     name='eventio',
-    version='0.16.0',
+    version='0.16.1',
     description='Python read-only implementation of the EventIO file format',
     long_description=long_description,
     url='https://github.com/fact-project/pyeventio',


### PR DESCRIPTION
Due to #142,  I had a quick look at the code and the dictionary keys 'camera_settings' is missing from telescope_description
```
telescope_description.keys() = dict_keys(['camera_organization', 'pixel_settings', 'disabled_pixels', 'camera_software_settings', 'drive_settings', 'pointing_correction'])
```
So i inspected a bit the code and found that it seems like in this function which is being looped:
https://github.com/cta-observatory/pyeventio/blob/6050c17c7e0feb8fddd38e2d8fc4f64e12eebadb/eventio/simtel/simtelfile.py#L91

there is one extra `next(self)` here:
https://github.com/cta-observatory/pyeventio/blob/6050c17c7e0feb8fddd38e2d8fc4f64e12eebadb/eventio/simtel/simtelfile.py#L112
which is preventing the 'CameraSettings' class from being copied to `telescope_descriptions_types`

I've commented this line and now I can read almost all the simtel files, apart from gamma_20deg_180deg_run100___cta-prod3-lapalma3-2147m-LaPalma.simtel.gz  which raises an error:
```
/home/thomas/Programs/anaconda3/envs/cta-dev/lib/python3.6/site-packages/astropy/units/quantity.py:639: 
RuntimeWarning: invalid value encountered in sqrt
  result = super().__array_ufunc__(function, method, *arrays, **kwargs)
```
I have no idea why this error is raised and if this is a good fix, but now I can read the simtel files again.

Feel free to change this PR...mine is just a temporary personal fix :sweat_smile: 