### PR TITLE
Implement yielding of calibration events, fixes #151

### DIFF
--- a/eventio/simtel/objects.py
+++ b/eventio/simtel/objects.py
@@ -1524,6 +1524,15 @@ class PixelList(EventIOObject):
 class CalibrationEvent(EventIOObject):
     eventio_type = 2028
 
+    def __init__(self, header, filehandle):
+        super().__init__(header, filehandle)
+        self.type = self.header.id
+
+    def __repr__(self):
+        return '{}[{}](type={})'.format(
+            self.__class__.__name__, self.eventio_type, self.type
+        )
+
 
 class AuxiliaryDigitalTraces(EventIOObject):
     eventio_type = 2029

--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -96,6 +96,7 @@ class SimTelFile(EventIOFile):
         # any of the objeccts in check is not None anymore
         check = []
         while not any(o for o in check):
+            self.next_low_level()
             check = [
                 self.current_mc_shower,
                 self.current_array_event,
@@ -103,7 +104,6 @@ class SimTelFile(EventIOFile):
                 self.laser_calibrations,
                 self.camera_monitorings,
             ]
-            self.next_low_level()
 
         self._first_event_byte = self.tell()
 

--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -93,7 +93,7 @@ class SimTelFile(EventIOFile):
 
         # read the header:
         # assumption: the header is done when
-        # any of the objeccts in check is not None anymore
+        # any of the objects in check is not None anymore
         check = []
         while not any(o for o in check):
             self.next_low_level()

--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -14,6 +14,7 @@ from .objects import (
     ADCSamples,
     ADCSums,
     ArrayEvent,
+    CalibrationEvent,
     CameraMonitoring,
     CameraOrganization,
     CameraSettings,
@@ -39,6 +40,17 @@ from .objects import (
 )
 
 
+telescope_descriptions_types = (
+    CameraSettings,
+    CameraOrganization,
+    PixelSettings,
+    DisabledPixels,
+    CameraSoftwareSettings,
+    DriveSettings,
+    PointingCorrection,
+)
+
+
 log = logging.getLogger(__name__)
 
 
@@ -56,7 +68,7 @@ class NoTrackingPositions(Exception):
 
 
 class SimTelFile(EventIOFile):
-    def __init__(self, path, allowed_telescopes=None):
+    def __init__(self, path, allowed_telescopes=None, skip_calibration=False):
         super().__init__(path)
 
         self.path = path
@@ -76,11 +88,21 @@ class SimTelFile(EventIOFile):
         self.current_photoelectron_sum = None
         self.current_photoelectrons = {}
         self.current_array_event = None
+        self.current_calibration_event = None
+        self.skip_calibration = skip_calibration
 
         # read the header:
         # assumption: the header is done when
-        # self.current_mc_shower is not None anymore
-        while self.current_mc_shower is None:
+        # any of the objeccts in check is not None anymore
+        check = []
+        while not any(o for o in check):
+            check = [
+                self.current_mc_shower,
+                self.current_array_event,
+                self.current_calibration_event,
+                self.laser_calibrations,
+                self.camera_monitorings,
+            ]
             self.next_low_level()
 
         self._first_event_byte = self.tell()
@@ -89,26 +111,21 @@ class SimTelFile(EventIOFile):
         return self.iter_array_events()
 
     def next_low_level(self):
-        telescope_descriptions_types = (
-            CameraSettings,
-            CameraOrganization,
-            PixelSettings,
-            DisabledPixels,
-            CameraSoftwareSettings,
-            DriveSettings,
-            PointingCorrection,
-        )
         o = next(self)
 
         if isinstance(o, History):
             self.history.append(o)
+
         elif isinstance(o, RunHeader):
             self.header = o.parse()
             self.n_telescopes = self.header['n_telescopes']
+
         elif isinstance(o, MCRunHeader):
             self.mc_run_headers.append(o.parse())
+
         elif isinstance(o, iact.InputCard):
             self.corsika_inputcards.append(o.parse())
+
         elif isinstance(o, telescope_descriptions_types):
             key = camel_to_snake(o.__class__.__name__)
             self.telescope_descriptions[o.telescope_id][key] = o.parse()
@@ -131,7 +148,12 @@ class SimTelFile(EventIOFile):
                 o,
                 self.allowed_telescopes
             )
-
+        elif isinstance(o, CalibrationEvent):
+            if not self.skip_calibration:
+                self.current_calibration_event = parse_array_event(
+                    next(o),
+                    self.allowed_telescopes,
+                )
         elif isinstance(o, CameraMonitoring):
             self.camera_monitorings[o.telescope_id].update(o.parse())
 
@@ -157,7 +179,6 @@ class SimTelFile(EventIOFile):
                 yield next_event
 
     def try_build_mc_event(self):
-        self.next_low_level()
         if self.current_mc_event:
             event_data = {
                 'event_id': self.current_mc_event_id,
@@ -166,6 +187,7 @@ class SimTelFile(EventIOFile):
             }
             self.current_mc_event = None
             return event_data
+        self.next_low_level()
 
     def iter_array_events(self):
         self._next_header_pos = self._first_event_byte
@@ -181,7 +203,6 @@ class SimTelFile(EventIOFile):
         '''check if all necessary info for an event was found,
         then make an event and invalidate old data
         '''
-        self.next_low_level()
 
         if self.current_array_event:
             if (
@@ -192,6 +213,7 @@ class SimTelFile(EventIOFile):
                 return None
 
             event_data = {
+                'type': 'data',
                 'event_id': self.current_mc_event_id,
                 'mc_shower': self.current_mc_shower,
                 'mc_event': self.current_mc_event,
@@ -214,6 +236,37 @@ class SimTelFile(EventIOFile):
             self.current_array_event = None
 
             return event_data
+
+        elif self.current_calibration_event:
+            event = self.current_calibration_event
+            if (
+                self.allowed_telescopes
+                and not self.current_array_event['telescope_events']
+            ):
+                self.current_calibration_event = None
+                return None
+
+            event_data = {
+                'type': 'calibration',
+                'telescope_events': event['telescope_events'],
+                'tracking_positions': event['tracking_positions'],
+                'trigger_information': event['trigger_information'],
+            }
+
+            event_data['camera_monitorings'] = {
+                telescope_id: copy(self.camera_monitorings[telescope_id])
+                for telescope_id in event.keys()
+            }
+            event_data['laser_calibrations'] = {
+                telescope_id: copy(self.laser_calibrations[telescope_id])
+                for telescope_id in event.keys()
+            }
+
+            self.current_calibration_event = None
+
+            return event_data
+
+        self.next_low_level()
 
 
 def parse_array_event(array_event, allowed_telescopes=None):

--- a/tests/simtel/test_simtel_objects.py
+++ b/tests/simtel/test_simtel_objects.py
@@ -11,6 +11,7 @@ prod2_file = 'tests/resources/gamma_test.simtel.gz'
 camorgan_v2_file = 'tests/resources/test_camorganv2.simtel.gz'
 prod4b_sst1m_file = 'tests/resources/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz'
 prod4b_astri_file = 'tests/resources/gamma_20deg_0deg_run103___cta-prod4-sst-astri_desert-2150m-Paranal-sst-astri.simtel.gz'
+calib_path = 'tests/resources/calib_events.simtel.gz'
 
 
 test_files = [
@@ -603,9 +604,15 @@ def test_2027_3_objects():
     '''
 
 
-@pytest.mark.xfail
 def test_2028():
-    assert False
+    from eventio.simtel.objects import CalibrationEvent, ArrayEvent
+
+    with EventIOFile(calib_path) as f:
+        n_events = 0
+        for event in yield_toplevel_of_type(f, CalibrationEvent):
+            assert isinstance(next(event), ArrayEvent)
+            n_events += 1
+        assert n_events > 0
 
 
 @pytest.mark.xfail

--- a/tests/simtel/test_simtelfile.py
+++ b/tests/simtel/test_simtelfile.py
@@ -8,6 +8,7 @@ prod4_path = 'tests/resources/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-
 # using a zstd file ensures SimTelFile is not seeking back, when reading
 # a file
 prod4_zst_path = 'tests/resources/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.zst'
+calib_path = 'tests/resources/calib_events.simtel.gz'
 
 
 test_paths = [prod2_path, prod3_path, prod4_path]
@@ -55,8 +56,8 @@ def test_show_event_is_not_empty_and_has_some_members_for_sure():
                 'profiles'
             }
 
-            print(event.keys())
             assert event.keys() == {
+                'type',
                 'event_id',
                 'mc_shower',
                 'mc_event',
@@ -123,12 +124,9 @@ def test_iterate_complete_file_zst():
 
 def test_iterate_mc_events():
     expected = 200
-    try:
-        with SimTelFile(prod4_path) as f:
-            for counter, event in enumerate(f.iter_mc_events(), start=1):
-                pass
-    except (EOFError, IndexError):  # truncated files might raise these...
-        pass
+    with SimTelFile(prod4_path) as f:
+        for counter, event in enumerate(f.iter_mc_events(), start=1):
+            pass
     assert counter == expected
 
 
@@ -147,3 +145,21 @@ def test_allowed_tels():
             pass
 
     assert n_read == 3
+
+
+def test_calibration_events():
+    with SimTelFile(calib_path) as f:
+        i = 0
+        for event in f:
+            assert event['type'] == 'calibration'
+            i += 1
+        assert i >= 1
+
+
+def test_skip_calibration_events():
+    with SimTelFile(calib_path, skip_calibration=True) as f:
+        i = 0
+        for event in f:
+            if event['type'] == 'calibration':
+                i += 1
+        assert i == 0


### PR DESCRIPTION
@kpfrang provided me with a 400 MB file containing Calibration events (Type 2028).

Those are just container objects with a single `ArrayEvent` inside.

I implemented yielding them in `SimTelFile`


The testfile ist 7.6 MB, most of it beiing telescope definitions. @kpfrang set, he could maube produce a smaller file on monday, so it might be good to wait until then.