### PR TITLE
Move timestamp parsing for History out of __init__

### DIFF
--- a/eventio/simtel/objects.py
+++ b/eventio/simtel/objects.py
@@ -61,25 +61,19 @@ class History(EventIOObject):
 class HistoryCommandLine(EventIOObject):
     eventio_type = 71
 
-    def __init__(self, header, filehandle):
-        super().__init__(header, filehandle)
-        self.timestamp = read_int(self)
-
     def parse(self):
-        self.seek(4)  # skip the int, we already read in init
-        return read_eventio_string(self)
+        timestamp = read_int(self)
+        string = read_eventio_string(self)
+        return timestamp, string
 
 
 class HistoryConfig(EventIOObject):
     eventio_type = 72
 
-    def __init__(self, header, filehandle):
-        super().__init__(header, filehandle)
-        self.timestamp = read_int(self)
-
     def parse(self):
-        self.seek(4)  # skip the int, we already read in init
-        return read_eventio_string(self)
+        timestamp = read_int(self)
+        string = read_eventio_string(self)
+        return timestamp, string
 
 
 class RunHeader(EventIOObject):

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ with open('README.rst') as f:
 
 setup(
     name='eventio',
-    version='0.18.0',
+    version='0.19.0',
     description='Python read-only implementation of the EventIO file format',
     long_description=long_description,
     url='https://github.com/fact-project/pyeventio',

--- a/tests/simtel/test_simtel_objects.py
+++ b/tests/simtel/test_simtel_objects.py
@@ -61,8 +61,8 @@ def test_71_3_objects():
 
     with EventIOFile(prod2_file) as f:
         for i, o in enumerate(yield_n_and_assert(f, HistoryCommandLine, n=3)):
-            d = parse_and_assert_consumption(o, limit=3)
-            assert isinstance(d, bytes)
+            t, s = parse_and_assert_consumption(o, limit=3)
+            assert isinstance(s, bytes)
 
 
 def test_72_3_objects():
@@ -70,8 +70,8 @@ def test_72_3_objects():
 
     with EventIOFile(prod2_file) as f:
         for i, o in enumerate(yield_n_and_assert(f, HistoryConfig, n=3)):
-            d = parse_and_assert_consumption(o, limit=3)
-            assert isinstance(d, bytes)
+            t, s = parse_and_assert_consumption(o, limit=3)
+            assert isinstance(s, bytes)
 
 
 def test_2000_1_object():


### PR DESCRIPTION
Makes skiping these history objects a little faster.