### PR TITLE
No parsing in __init__ of ArrayOffsets

### DIFF
--- a/eventio/iact/__init__.py
+++ b/eventio/iact/__init__.py
@@ -123,9 +123,8 @@ class IACTFile(EventIOFile):
             reuse_object = next(self)
             check_type(reuse_object, ArrayOffsets)
 
-            n_reuses = reuse_object.n_reuses
-            array_offsets = reuse_object.parse()
-            time_offset = reuse_object.time_offset
+            time_offset, array_offsets = reuse_object.parse()
+            n_reuses = len(array_offsets)
 
             longitudinal = None
             particles = None

--- a/eventio/iact/objects.py
+++ b/eventio/iact/objects.py
@@ -131,12 +131,6 @@ class ArrayOffsets(EventIOObject):
         1: [('x', 'f4'), ('y', 'f4'), ('weight', 'f4')],
     }
 
-    def __init__(self, header, filehandle):
-        super().__init__(header, filehandle)
-        self.n_arrays = read_int(self)
-        self.time_offset = read_float(self)
-        self.n_reuses = self.n_arrays
-
     def parse(self):
         '''
         Read the data in this EventIOItem
@@ -145,20 +139,16 @@ class ArrayOffsets(EventIOObject):
         with a row for each array. This object is used to store the
         array position and contains one set of coordinates for each reuse.
         '''
-        self.seek(8)
         assert_max_version(self, 1)
+        self.seek(0)
 
-        return read_array(
+        n_arrays = read_int(self)
+        time_offset = read_float(self)
+
+        return time_offset, read_array(
             self,
             dtype=self.dtypes[self.header.version],
-            count=self.n_arrays,
-        )
-
-    def __str__(self):
-        return '{}[{}](n_reuses={})'.format(
-            self.__class__.__name__,
-            self.header.type,
-            self.n_reuses,
+            count=n_arrays,
         )
 
 

--- a/tests/iact/test_iact_objects.py
+++ b/tests/iact/test_iact_objects.py
@@ -77,9 +77,9 @@ def test_corsika_array_offsets():
             obj = next(f)
 
         assert isinstance(obj, ArrayOffsets)
-        assert obj.n_arrays == 1
 
-        offsets = obj.parse()
+        time_offset, offsets = obj.parse()
+        assert len(offsets) == 1
         assert offsets['x'][0] == approx(-506.9717102050781)
         assert offsets['y'][0] == approx(-3876.447265625)
 


### PR DESCRIPTION
Makes it faster to read only the event headers and run headers.

I think we generally should avoid any parsing of the data block in `__init__` methods of these objects.