### PR TITLE
Reorder ifs

### DIFF
--- a/eventio/base.py
+++ b/eventio/base.py
@@ -163,13 +163,14 @@ class EventIOFile:
 
 
 def check_size_or_raise(data, expected_length, zero_ok=True):
-    if len(data) == 0:
+    length = len(data)
+    if length == 0:
         if zero_ok:
             raise StopIteration
         else:
             raise EOFError('File seems to be truncated')
 
-    if len(data) < expected_length:
+    if length < expected_length:
         raise EOFError('File seems to be truncated')
 
 


### PR DESCRIPTION
Reorder if statements, so that the most often occuring containers are checked first, thus reducing the number of evaluated statements.

Resultet in roughtly 10 % faster reading of a largish simtel file (uncompressed)