### PR TITLE
Numpy c api

### DIFF
--- a/eventio/__init__.py
+++ b/eventio/__init__.py
@@ -6,7 +6,7 @@ from .simtel import SimTelFile
 from .histograms import Histograms
 
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 __all__ = [
     'EventIOFile',

--- a/eventio/iact/objects.py
+++ b/eventio/iact/objects.py
@@ -357,8 +357,8 @@ class RunEnd(EventIOObject):
         n = read_int(self)
         if n != 3:
             raise WrongSize('Expected 3 floats, but found {}'.format(n))
-        d = bytearray(self.read())
-        d.extend(b'\x00' * (270 * 4))
+        d = bytearray(273 * 4)
+        d[:n * 4] = self.read()
         return parse_run_end(d)
 
 

--- a/eventio/tools.py
+++ b/eventio/tools.py
@@ -83,7 +83,6 @@ def read_time(f):
 
 
 def read_varint(f):
-    # this is mostly a verbatim copy from eventio.c lines 1082ff
     u = read_unsigned_varint(f)
     # u values of 0,1,2,3,4,... here correspond to signed values of
     #   0,-1,1,-2,2,... We have to test the least significant bit:
@@ -95,10 +94,9 @@ def read_varint(f):
 
 def read_unsigned_varint(f):
     '''this returns a python integer'''
-    # this is a reimplementation from eventio.c lines 797ff
     var_int_bytes = bytearray(f.read(1))
     var_int_length = get_length_of_varint(var_int_bytes[0])
-    if var_int_length - 1 > 0:
-        var_int_bytes.extend(f.read(var_int_length - 1))
+    if var_int_length > 1:
+        var_int_bytes += f.read(var_int_length - 1)
 
     return parse_varint(var_int_bytes)


### PR DESCRIPTION
Using the numpy c API instead of python functions in cython code removes some overhead, parsing these varint arrays is now 10 % faster in a simple prod3 file.