### PR TITLE
Store photoelectron arrival information in two 1d arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDE
+.idea

--- a/eventio/iact/objects.py
+++ b/eventio/iact/objects.py
@@ -401,8 +401,8 @@ class InputCard(EventIOObject):
         n_strings = read_int(self)
         input_card = bytearray()
         for i in range(n_strings):
-            input_card.extend(read_string(self))
-            input_card.append(ord('\n'))
+            input_card += read_string(self)
+            input_card += b'\n'
         return input_card
 
 

--- a/eventio/iact/objects.py
+++ b/eventio/iact/objects.py
@@ -314,7 +314,7 @@ class PhotoElectrons(EventIOObject):
         data = self.read()
 
         pe.update(PhotoElectrons.parse_1208(
-            data, pe['n_pixels'], pe['non_empty'], self.header.version, flags
+            data, pe['n_pixels'], pe['non_empty'], self.header.version, flags, pe['n_pe']
         ))
 
         return pe

--- a/eventio/var_int.pyx
+++ b/eventio/var_int.pyx
@@ -370,11 +370,10 @@ def parse_1208(
 
     cdef cnp.npy_intp[1] shape = [n_pixels]
     cdef cnp.ndarray[float, ndim=1] photoelectrons = cnp.PyArray_ZEROS(1, shape, cnp.NPY_FLOAT32, False)
-    cdef cnp.ndarray[float, ndim=1] mean_time = cnp.PyArray_SimpleNew(1, shape, cnp.NPY_FLOAT32)
-    cnp.PyArray_FillWithScalar(mean_time, NAN)
     cdef cnp.ndarray[int32_t, ndim=1] photon_counts = None
 
-    cdef list time = [[] for _ in range(n_pixels)]
+    cdef list pixel_array = []
+    cdef list time_array = []
     cdef list amplitude
 
     cdef bint has_amplitudes = flags & 1
@@ -403,16 +402,12 @@ def parse_1208(
         pos += 4
 
         photoelectrons[pix_id] = n_pe
-        if n_pe > 0:
-            mean_time[pix_id] = 0.0
 
         for j in range(n_pe):
             t = (<float*> &data[pos])[0]
-            time[pix_id].append(t)
-            mean_time[pix_id] += t
+            pixel_array.append(pix_id)
+            time_array.append(t)
             pos += 4
-
-        mean_time[pix_id] /= n_pe
 
         if has_amplitudes:
             for j in range(n_pe):
@@ -420,8 +415,8 @@ def parse_1208(
                 pos += 4
 
     result['photoelectrons'] = photoelectrons
-    result['time'] = time
-    result['mean_time'] = mean_time
+    result['photoelectron_arrival_pixel'] = np.array(pixel_array)
+    result['photoelectron_arrival_time'] = np.array(time_array)
 
     if has_amplitudes:
         result['amplitude'] = amplitude

--- a/tests/iact/test_iact_objects.py
+++ b/tests/iact/test_iact_objects.py
@@ -24,16 +24,12 @@ def test_photo_electrons():
             assert 0 <= data['non_empty'] <= data['n_pixels']
             assert len(data['photoelectrons']) == data['n_pixels']
             assert data['photoelectrons'].sum() == data['n_pe']
-            assert len(data['time']) == 2368
-            assert sum(len(pixel) for pixel in data['time']) == data['n_pe']
+            assert len(data['photoelectron_arrival_pixel']) == data['n_pe']
+            assert len(data['photoelectron_arrival_time']) == data['n_pe']
 
             # times should be within 200 nanoseconds
-            assert all(0 <= t <= 200 for pixel in data['time'] for t in pixel)
-            mean_time = np.array([
-                np.mean(t) if len(t) > 0 else np.nan
-                for t in data['time']
-            ])
-            assert np.allclose(data['mean_time'], mean_time, equal_nan=True)
+            assert all(0 <= data['photoelectron_arrival_time'])
+            assert all(data['photoelectron_arrival_time'] <= 200)
 
             not_read = o.read()
             assert len(not_read) == 0 or all(b == 0 for b in not_read)

--- a/tests/iact/test_iact_objects.py
+++ b/tests/iact/test_iact_objects.py
@@ -24,12 +24,12 @@ def test_photo_electrons():
             assert 0 <= data['non_empty'] <= data['n_pixels']
             assert len(data['photoelectrons']) == data['n_pixels']
             assert data['photoelectrons'].sum() == data['n_pe']
-            assert len(data['photoelectron_arrival_pixel']) == data['n_pe']
-            assert len(data['photoelectron_arrival_time']) == data['n_pe']
+            assert len(data['pixel_id']) == data['n_pe']
+            assert len(data['time']) == data['n_pe']
 
             # times should be within 200 nanoseconds
-            assert all(0 <= data['photoelectron_arrival_time'])
-            assert all(data['photoelectron_arrival_time'] <= 200)
+            assert np.all(0 <= data['time'])
+            assert np.all(data['time'] <= 200)
 
             not_read = o.read()
             assert len(not_read) == 0 or all(b == 0 for b in not_read)


### PR DESCRIPTION
Replaces the "list of lists" containing photoelectrons arrival time (`array_event['photoelectrons'][tel_id]['time']`) with two 1d arrays:

`array_event['photoelectrons'][tel_id]['photoelectron_arrival_pixel']`
`array_event['photoelectrons'][tel_id]['photoelectron_arrival_time']`

These arrays are easier to operate with instead of the list of lists.

Also removed calculation of mean_time from eventio. Instead, the following can be performed:
```python
        sum_ = np.zeros(n_pixels)
        n = np.zeros(n_pixels)
        np.add.at(sum_, pixel_array, time_array)
        np.add.at(n, pixel_array, 1)
        mean_time = np.divide(sum_, n, out=np.full_like(sum_, np.nan), where=n != 0)
```

## Benchmarks:

```python
def get_mean_time_old():
    with eventio.SimTelFile(path) as f:
        for array_event in f:
            array_event['photoelectrons'][0]['mean_time']
            break
```
142 ms ± 15.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

```python
def get_mean_time_new():
    with eventio.SimTelFile(path) as f:
        for array_event in f:
            pixel_array = array_event['photoelectrons'][0]['photoelectron_arrival_pixel']
            time_array = array_event['photoelectrons'][0]['photoelectron_arrival_time']
            n_pixels = array_event['photoelectrons'][0]['photoelectrons'].size
            
            
            sum_ = np.zeros(n_pixels)
            n = np.zeros(n_pixels)
            np.add.at(sum_, pixel_array, time_array)
            np.add.at(n, pixel_array, 1)
            mean_time = np.divide(sum_, n, out=np.full_like(sum_, np.nan), where=n != 0)
            break
```
134 ms ± 2.08 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
