### PR TITLE
Parse simtel history in simtel file

### DIFF
--- a/eventio/__init__.py
+++ b/eventio/__init__.py
@@ -6,7 +6,7 @@ from .simtel import SimTelFile
 from .histograms import Histograms
 
 
-__version__ = '1.4.2'
+__version__ = '1.5.0'
 
 __all__ = [
     'EventIOFile',

--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -188,7 +188,8 @@ class SimTelFile(EventIOFile):
                 self.current_calibration_event['calibration_type'] = o.type
 
         elif isinstance(o, History):
-            self.history.append(o)
+            for sub in o:
+                self.history.append(sub.parse())
 
         elif isinstance(o, Histograms):
             self.histograms = o.parse()


### PR DESCRIPTION
Before, a the History Object was put in unparsed, which is not really helpful.