### PR TITLE
Require "oldest-supported-numpy" in pyproject.toml, fixes #226

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "wheel", "Cython", "numpy"]
+requires = ["setuptools >= 40.6.0", "wheel", "Cython", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if ext == '.c':
 
 
 with open('eventio/__init__.py') as f:
-    m = re.search("__version__ = [\"']([0-9.]+)[\"']", f.read())
+    m = re.search("__version__ = [\"'](.*)[\"']", f.read())
     version = m.groups()[0]
 
 setup(


### PR DESCRIPTION
This fixes issues as reported here: #226 

See also https://pypi.org/project/oldest-supported-numpy/