### PR TITLE
Fix parsing of ArrayOffsets (type 1203)

### DIFF
--- a/eventio/iact/objects.py
+++ b/eventio/iact/objects.py
@@ -145,11 +145,19 @@ class ArrayOffsets(EventIOObject):
         n_arrays = read_int(self)
         time_offset = read_float(self)
 
-        return time_offset, read_array(
+        n_par = len(self.dtypes[self.header.version])
+
+        offsets = read_array(
             self,
-            dtype=self.dtypes[self.header.version],
-            count=n_arrays,
+            dtype=np.float32,
+            count=n_arrays * n_par,
         )
+
+        offsets = np.core.records.fromarrays(
+                                offsets.reshape(n_par, n_arrays),
+                                dtype=self.dtypes[self.header.version])
+     
+        return time_offset, offsets
 
 
 class TelescopeData(EventIOObject):


### PR DESCRIPTION
Hi all,

When exploring some CORSIKA output files where the events are reused multiple times, we noticed, that the parsing of the impact positions is twisted.

The impact positions are arranged as `x1, x2, x3,  ..... , y1, y2, .....` and not `x1, y1, x2, y2`

This is at least true for the dtype without weights in `ArrayOffsets`.
I didn't have a file including weights at hand to test it.

On another note: Really nice project, thanks for the great work!
