### PR TITLE
Fix breaking change in 1.9.0 of putting none instead of dict for missing information

### DIFF
--- a/eventio/simtel/simtelfile.py
+++ b/eventio/simtel/simtelfile.py
@@ -292,9 +292,9 @@ class SimTelFile(EventIOFile):
                 'telescope_events': self.current_array_event['telescope_events'],
                 'tracking_positions': self.current_array_event['tracking_positions'],
                 'trigger_information': self.current_array_event['trigger_information'],
-                'photons': None,
-                'emitter': None,
-                'photoelectrons': None,
+                'photons': {},
+                'emitter': {},
+                'photoelectrons': {},
                 'photoelectron_sums': None,
             }
 

--- a/tests/simtel/test_simtelfile.py
+++ b/tests/simtel/test_simtelfile.py
@@ -233,6 +233,15 @@ def test_photons():
         assert len(e['emitter']) == 0
 
 
+def test_missing_photons():
+    with SimTelFile('tests/resources/gamma_test.simtel.gz') as f:
+        e = next(iter(f))
+
+        assert e['photons'] == {}
+        assert e['photoelectrons'] == {}
+        assert e['emitter'] == {}
+
+
 def test_history_meta():
     with SimTelFile(history_meta_path) as f:
         assert isinstance(f.global_meta, dict)


### PR DESCRIPTION
With the last PR I unfortunately introduced a breaking change that needs to be fixed for ctapipe.

The breaking change was replacing the empty dict with None for some of the event data.