### PR TITLE
Avoid annoying error message when using less

### DIFF
--- a/eventio/scripts/print_simtel_history.py
+++ b/eventio/scripts/print_simtel_history.py
@@ -7,7 +7,7 @@ parser = ArgumentParser()
 parser.add_argument('inputfile')
 
 
-def main():
+def print_history():
     args = parser.parse_args()
 
     with EventIOFile(args.inputfile) as f:
@@ -18,6 +18,13 @@ def main():
                 t = datetime.fromtimestamp(t)
                 print(f'{t:%Y-%m-%dT%H:%M:%S}', line.decode('utf-8').strip())
             o = next(f)
+
+
+def main():
+    try:
+        print_history()
+    except BrokenPipeError:
+        pass
 
 
 if __name__ == '__main__':

--- a/eventio/scripts/print_simtel_metaparams.py
+++ b/eventio/scripts/print_simtel_metaparams.py
@@ -8,7 +8,7 @@ parser.add_argument('inputfile')
 parser.add_argument('--encoding', default='utf8', help='Encoding to use for decoding METAPARAMs')
 
 
-def main():
+def print_metaparams():
     args = parser.parse_args()
 
     with EventIOFile(args.inputfile) as f:
@@ -40,6 +40,12 @@ def main():
             for k, v in o.parse().items():
                 print(k.decode(args.encoding), "=", v.decode(args.encoding))
 
+
+def main():
+    try:
+        print_metaparams()
+    except BrokenPipeError:
+        pass
 
 
 if __name__ == '__main__':

--- a/eventio/scripts/print_structure.py
+++ b/eventio/scripts/print_structure.py
@@ -18,7 +18,7 @@ parser.add_argument(
 )
 
 
-def main():
+def print_structure():
     args = parser.parse_args()
 
     conv = str if not args.repr else repr
@@ -49,6 +49,13 @@ def main():
                     print('    ' * level, conv(o))
         except EOFError as e:
             print(e)
+
+
+def main():
+    try:
+        print_structure()
+    except BrokenPipeError:
+        pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Catch BrokenPipeError in the scripts that print a lot of information
so that there is no annoying error when exiting less before all output
has been read.