### PR TITLE
Fix reading of central trigger object in case of new mono trigger

### DIFF
--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:

--- a/tests/simtel/test_simtel_objects.py
+++ b/tests/simtel/test_simtel_objects.py
@@ -5,7 +5,9 @@ from eventio import EventIOFile
 from eventio.search_utils import (
     yield_toplevel_of_type,
     yield_n_subobjects,
+    yield_subobjects,
 )
+from eventio.simtel.objects import TriggerInformation
 
 prod2_file = 'tests/resources/gamma_test.simtel.gz'
 camorgan_v2_file = 'tests/resources/test_camorganv2.simtel.gz'
@@ -824,3 +826,9 @@ def test_2034():
             assert isinstance(telescope_data, TelescopeData)
             photo_electrons = next(telescope_data)
             assert isinstance(photo_electrons, PhotoElectrons)
+
+
+def test_mono_trigger():
+    with EventIOFile("tests/resources/mono_trigger.simtel.zst") as f:
+        for trigger in yield_subobjects(f, TriggerInformation):
+            trigger.parse()

--- a/tests/simtel/test_simtel_objects.py
+++ b/tests/simtel/test_simtel_objects.py
@@ -829,6 +829,7 @@ def test_2034():
 
 
 def test_mono_trigger():
+    """Regression test for #261"""
     with EventIOFile("tests/resources/mono_trigger.simtel.zst") as f:
         for trigger in yield_subobjects(f, TriggerInformation):
             trigger.parse()


### PR DESCRIPTION
The code made the assumption that the trigger mask is stored as a "normal" 8-bit unsigned integer instead of a variable length unsigned integer. 

This assumption was always valid until now, but the new mono trigger requires correctly reading the masks as variable length integers.