### PR TITLE
Update setup.py / pyproject.toml to follow latest numpy and cython docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=64", "Cython", "oldest-supported-numpy", 'setuptools_scm[toml]>=8']
+requires = ["setuptools>=64", "Cython", "numpy>=1.25", 'setuptools_scm[toml]>=8']
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,11 +24,10 @@ classifiers =
 	Operating System :: OS Independent
 	Programming Language :: Python
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.6
-	Programming Language :: Python :: 3.7
-	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
+	Programming Language :: Python :: 3.11
+	Programming Language :: Python :: 3.12
 	Programming Language :: Python :: 3 :: Only
 	Topic :: Scientific/Engineering :: Astronomy
 	Topic :: Scientific/Engineering :: Physics

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ kwargs = dict(
     ]
 )
 
-# if we have cython, use the cython file if not the c file
 extensions = [
     Extension(
         'eventio.header',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extensions = [
 setup(
     use_scm_version={"write_to": os.path.join("src", "eventio", "_version.py")},
     ext_modules=cythonize(extensions),
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=[
         'numpy >= 1.21',
         'corsikaio ~= 0.3.3',


### PR DESCRIPTION
Remove all the magic for allowing compilation of bundled c files without Cython, this was obsolete since we python `Cython` into the build requirements in `pyproject.toml`. Supporting the case where people don't have cython doesn't make sense, since pip ensures it.

Numpy 1.25 made `oldest-supported-numpy` obsolete, we can chose the lowest version of numpy we want to support with a definition as long as we compile using at least numpy 1.25.


