### PR TITLE
Add diff and json feature to eventio_print_simtel_metaparams

### DIFF
--- a/src/eventio/scripts/print_simtel_metaparams.py
+++ b/src/eventio/scripts/print_simtel_metaparams.py
@@ -1,17 +1,52 @@
-from eventio import EventIOFile
-from argparse import ArgumentParser
-from eventio.simtel import HistoryMeta
-from eventio.search_utils import yield_toplevel_of_type
+import sys
 
-parser = ArgumentParser()
+import json
+from eventio import EventIOFile
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from eventio.simtel import HistoryMeta
+from difflib import unified_diff
+
+parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
 parser.add_argument('inputfile')
 parser.add_argument('--encoding', default='utf8', help='Encoding to use for decoding METAPARAMs')
+parser.add_argument('--tel-diff', nargs=2, type=int)
+parser.add_argument("--json", action="store_true", help="output as json")
 
 
 def print_metaparams():
     args = parser.parse_args()
 
-    with EventIOFile(args.inputfile) as f:
+    global_meta, telescope_meta = read_meta(args.inputfile, args.encoding)
+
+    if args.tel_diff is not None:
+        tel_a, tel_b = args.tel_diff
+
+        meta_a = telescope_meta[tel_a]
+        meta_b = telescope_meta[tel_b]
+
+        diff = unified_diff(format_meta(meta_a).splitlines(), format_meta(meta_b).splitlines())
+        for line in diff:
+            print(line)
+        sys.exit(0)
+
+    if args.json:
+        meta = {"global": global_meta, "telescopes": telescope_meta}
+        print(json.dumps(meta, indent=2))
+        sys.exit(0)
+
+    if global_meta is not None:
+        print_meta(global_meta)
+
+    for tel_id, meta in telescope_meta.items():
+        print()
+        print_meta(meta, tel_id=tel_id)
+
+
+def read_meta(path, encoding):
+    global_meta = None
+    telescope_meta = {}
+
+    with EventIOFile(path) as f:
         found_meta = False
 
         for o in f:
@@ -27,18 +62,33 @@ def print_metaparams():
                     continue
 
             if o.header.id == -1:
-                s = "Global METAPARAMs"
-                print()
-                print(s)
-                print(len(s) * "-")
+                global_meta = decode(o.parse(), encoding)
             else:
-                s = f"METAPARAMs for telescope={o.header.id}"
-                print()
-                print(s)
-                print(len(s) * "-")
+                telescope_meta[o.header.id] = decode(o.parse(), encoding)
 
-            for k, v in o.parse().items():
-                print(k.decode(args.encoding), "=", v.decode(args.encoding))
+    return global_meta, telescope_meta
+
+
+def decode(meta, encoding):
+    return {
+        k.decode(encoding): v.decode(encoding)
+        for k, v in meta.items()
+    }
+
+
+def format_meta(meta):
+    return "\n".join(f"{k} = {v}" for k, v in meta.items())
+
+
+def print_meta(meta, tel_id=None):
+    if tel_id is None:
+        title = "Global METAPARAMs"
+    else:
+        title = f"METAPARAMs for telescope={tel_id}"
+
+    print(title)
+    print(len(title) * "-")
+    print(format_meta(meta))
 
 
 def main():

--- a/src/eventio/scripts/print_simtel_metaparams.py
+++ b/src/eventio/scripts/print_simtel_metaparams.py
@@ -9,8 +9,10 @@ from difflib import unified_diff
 parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
 parser.add_argument('inputfile')
 parser.add_argument('--encoding', default='utf8', help='Encoding to use for decoding METAPARAMs')
-parser.add_argument('--tel-diff', nargs=2, type=int)
-parser.add_argument("--json", action="store_true", help="output as json")
+
+group = parser.add_mutually_exclusive_group()
+group.add_argument('--tel-diff', nargs=2, type=int)
+group.add_argument("--json", action="store_true", help="output as json")
 
 
 def print_metaparams():


### PR DESCRIPTION
Allows passing `--tel-diff 1 2` to compare the meta parameters of two telescopes, e.g.:

```diff
❯ eventio_print_simtel_metaparams prod6_test_files/gamma_20deg_0deg_run000001___cta-prod6-2156m-LaPalma-dark+magic_cone10.simtel.zst --tel-diff 1 2
--- 

+++ 

@@ -1,21 +1,29 @@

-NIGHTSKY_BACKGROUND = all: 0.233591 
+NIGHTSKY_BACKGROUND = all: 0.241539 
 NSB_AUTOSCALE_AIRMASS = 0.84 0.29 
 MIRROR_CLASS = 0 
 FOCUS_OFFSET = 6.55 0 0 0 
 FOCAL_Length = 2800 
 EFFECTIVE_FOCAL_Length = 2923.7 0 0 0 0 
-MIRROR_LIST = mirror_CTA-N-LST1_v2019-03-31.dat
+MIRROR_LIST = mirror_CTA-N-LST2_v2020-04-07_rotated.dat
 CAMERA_DEGRADED_EFFICIENCY = 1 
 CAMERA_DEGRADED_MAP = none
 MIRROR_DEGRADED_REFLECTION = 0.8 
 PRIMARY_DEGRADED_MAP = none
 DEFAULT_TRIGger = AnalogSum
-CAMERA_CONFIG_FILE = camera_CTA-LST-1_analogsum21_v2020-04-14.dat
+CAMERA_CONFIG_FILE = camera_CTA-LST-234_analogsum21_v2020-04-14.dat
 OPTICS_CONFIG_NAME = LST
-OPTICS_CONFIG_VARIANT = LSTN-01 prototype
+OPTICS_CONFIG_VARIANT = LSTN-02
 OPTICS_CONFIG_VERSION = 2023-12-15 (Prod-6)
 CAMERA_CONFIG_NAME = LSTcam
-CAMERA_CONFIG_VARIANT = LST-1(N) prototype, with nsb_autoscale_airmass
+CAMERA_CONFIG_VARIANT = LSTN-02 camera, with auto-scaling NSB levels
 CAMERA_CONFIG_VERSION = 2022-07-01 (Prod-6)
+RANDOM_MONO_PROBability = 0.01 
+PARABOLIC_DISH = 1 
+DISH_SHAPE_Length = 2800 
+MIRROR_FOCAL_Length = 0 
+DISCRIMINATOR_PULSE_SHAPE = LST_pulse_shape_7dynode_high_intensity_pix1s.dat
+ASUM_THRESHold = 260.7 
+ASUM_CLIPping = 9999 
+ASUM_SHAPING_FILE = none
 MIRROR_DIAMETER = 24.774 m
 MIRROR_AREA = 386.97 m^2
```


Also added the `--json` flag to output as json