### PR TITLE
Fix ResourceWarnings when using the zcat implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,15 @@ exclude = ["eventio._dev_version"]
 [tool.setuptools_scm]
 version_file = "src/eventio/_version.py"
 
-
-[tool.pytest]
-addopts = "-v --durations=10"
+[tool.pytest.ini_options]
+minversion = "7"
+testpaths = ["tests"]
+log_cli_level = "INFO"
+xfail_strict = true
+# print summary of failed tests, force errors if settings are misspelled
+addopts = ["-ra", "--strict-config", "--strict-markers", "-v", "--durations=10"]
+filterwarnings = [
+    "error",
+    "ignore:File seems to be truncated:UserWarning",
+    "ignore:Version unknown:UserWarning",  # pycorsikaio
+]

--- a/src/eventio/base.py
+++ b/src/eventio/base.py
@@ -48,7 +48,7 @@ class PipeWrapper:
         return self.pos
 
     def close(self):
-        return self.pipe.close()
+        pass
 
     def tell(self):
         return self.pos
@@ -144,9 +144,16 @@ class EventIOFile:
         self.close()
 
     def close(self):
-        self._filehandle.close()
         if self.read_process is not None:
             self.read_process.terminate()
+            self.read_process.stdout.close()
+            self.read_process.stderr.close()
+            self.read_process.wait(timeout=1)
+
+        self._filehandle.close()
+
+    def __del__(self):
+        self.close()
 
 
 def check_size_or_raise(data, expected_length, zero_ok=True):

--- a/tests/simtel/test_compare_hessio.py
+++ b/tests/simtel/test_compare_hessio.py
@@ -1,5 +1,4 @@
 import pytest
-from pkg_resources import resource_filename
 import numpy as np
 pyhessio = pytest.importorskip("pyhessio")
 

--- a/tests/test_open_file.py
+++ b/tests/test_open_file.py
@@ -58,8 +58,7 @@ def test_types_gzip():
 def test_types_zcat():
     from eventio.base import PipeWrapper
     testfile = 'tests/resources/one_shower.dat.gz'
-    f = eventio.EventIOFile(testfile)
-
-    assert isinstance(f._filehandle, PipeWrapper)
-    types = [o.header.type for o in f]
-    assert types == [1200, 1212, 1201, 1202, 1203, 1204, 1209, 1210]
+    with eventio.EventIOFile(testfile) as f:
+        assert isinstance(f._filehandle, PipeWrapper)
+        types = [o.header.type for o in f]
+        assert types == [1200, 1212, 1201, 1202, 1203, 1204, 1209, 1210]


### PR DESCRIPTION
@GernotMaier I assigned you as reviewer as @orelgueta who did this for the last couple of PRs is on leave.

If you don't have the time, please just write and I'll look for someone else who can review (or you might suggest someone from the simulation team).

This fixes warnings that arose from not closing the `stderr` of the process opened to improve the speed of reading gzipped input fles.

Mainly fixed by closing both `stderr` and `stdout` of the `Popen` object in `close` and also calling `close` in `__del__`.

Some configuration added that should make sure we see warnings as CI failures.