### PR TITLE
Fix exception when closing non-eventio files

### DIFF
--- a/src/eventio/base.py
+++ b/src/eventio/base.py
@@ -63,6 +63,7 @@ class EventIOFile:
         self.read_process = None
         self.zstd = False
         self.next = None
+        self._filehandle = None
 
         if not is_eventio(path):
             raise ValueError('File {} is not an eventio file'.format(path))
@@ -151,7 +152,8 @@ class EventIOFile:
             self.read_process.stderr.close()
             self.read_process.wait(timeout=1)
 
-        self._filehandle.close()
+        if self._filehandle is not None:
+            self._filehandle.close()
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
If a non-eventio file is opened (either a file not in the expected formats, or an empty file such as caused by a failed run of sim_telarray), an exception is raised if `close()` is called on the `EventIOFile` object. This happens automatically if the variable goes out of scope, such as in the common operation of a loop over input files.

## Example

```python
# File: test.py

import sys
from eventio import EventIOFile

for _ in range(1):
  try:
    file = EventIOFile(sys.argv[1])
  except Exception as ex:
    print("Error:", ex)
    continue

  ## processing would go here ##
```

```
$ python test.py /dev/random
```

Output:
```
Error: File /dev/random is not an eventio file
Exception ignored in: <function EventIOFile.__del__ at 0x7fcfb01ce2a0>
Traceback (most recent call last):
  File "<snip>/lib/python3.12/site-packages/eventio/base.py", line 156, in __del__
    self.close()
  File "<snip>/lib/python3.12/site-packages/eventio/base.py", line 153, in close
    self._filehandle.close()
    ^^^^^^^^^^^^^^^^
AttributeError: 'EventIOFile' object has no attribute '_filehandle'
```

Fortunately in this case, the exception isn't considered fatal. But it is still noisy and can be fixed by checking the status of `_filehandle` before operating on it.

## Other notes
Incidentally, in the case of empty files, instead an opaque `IndexError` is raised by the method that attempts to read the file and discern its type. You can see this if you try `/dev/null` instead of `/dev/random` with this test script. But the follow-on issues are the same.