### PR TITLE
Update examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
           python iter_mc_events.py $RESOURCES/40k_pixels.simtel.zst
           python plot_events.py $RESOURCES/gamma_test.simtel.gz
           python plot_light_on_ground.py -i $RESOURCES/3_gammas_reuse_5.dat
-          # python plot_light_on_ground_by_particle.py
-          # python plot_light_on_ground_rgb.py
+          python plot_light_on_ground_by_particle.py $RESOURCES/proton_emitter.eventio.zst
+          python plot_light_on_ground_rgb.py $RESOURCES/proton_emitter.eventio.zst
           python plot_mc_pe.py -i $RESOURCES/gamma_20deg_0deg_run103___cta-prod4-sst-astri_desert-2150m-Paranal-sst-astri.simtel.gz
           python plot_production_3d.py -i $RESOURCES/3_gammas_reuse_5.dat
           python profile_simtel.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,14 +63,13 @@ jobs:
       - name: Run examples
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
+          RESOURCES: "../tests/resources/"
+          MPLBACKEND: agg
         run: |
           python --version
           pip install -e '.[examples]'
           cd examples
-          RESOURCES="../tests/resources/"
 
-          MPLBACKEND=agg
-          
           python iter_mc_events.py $RESOURCES/40k_pixels.simtel.zst
           python plot_events.py $RESOURCES/gamma_test.simtel.gz
           python plot_light_on_ground.py -i $RESOURCES/3_gammas_reuse_5.dat
@@ -79,7 +78,7 @@ jobs:
           python plot_mc_pe.py -i $RESOURCES/gamma_20deg_0deg_run103___cta-prod4-sst-astri_desert-2150m-Paranal-sst-astri.simtel.gz
           python plot_production_3d.py -i $RESOURCES/3_gammas_reuse_5.dat
           python profile_simtel.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
-          # python read_all_objects.py
+          python read_all_objects.py $RESOURCES/tests/resources/calib_true_pe.simtel.zst
           python read_simtel_corsika_events.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
           python trigger_times.py --max-shower-events 1 $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
           python try_simtelfile.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,11 +43,33 @@ jobs:
         run: |
           pytest --cov=eventio --cov-report=xml
 
+      - uses: codecov/codecov-action@v4
+
+  examples:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Run examples
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
+          python --version
           pip install -e '.[examples]'
           cd examples
           RESOURCES="../tests/resources/"
+
+          MPLBACKEND=agg
           
           # python iter_mc_events.py
           python plot_events.py $RESOURCES/gamma_test.simtel.gz
@@ -61,5 +83,3 @@ jobs:
           python read_simtel_corsika_events.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
           # python trigger_times.py 
           python try_simtelfile.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
-
-      - uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           python plot_mc_pe.py -i $RESOURCES/gamma_20deg_0deg_run103___cta-prod4-sst-astri_desert-2150m-Paranal-sst-astri.simtel.gz
           python plot_production_3d.py -i $RESOURCES/3_gammas_reuse_5.dat
           python profile_simtel.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
-          python read_all_objects.py $RESOURCES/tests/resources/calib_true_pe.simtel.zst
+          python read_all_objects.py $RESOURCES/calib_true_pe.simtel.zst
           python read_simtel_corsika_events.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
           python trigger_times.py --max-shower-events 1 $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
           python try_simtelfile.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
           MPLBACKEND=agg
           
-          # python iter_mc_events.py
+          python iter_mc_events.py $RESOURCES/40k_pixels.simtel.zst
           python plot_events.py $RESOURCES/gamma_test.simtel.gz
           python plot_light_on_ground.py -i $RESOURCES/3_gammas_reuse_5.dat
           # python plot_light_on_ground_by_particle.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,5 +81,5 @@ jobs:
           python profile_simtel.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
           # python read_all_objects.py
           python read_simtel_corsika_events.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
-          # python trigger_times.py 
+          python trigger_times.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
           python try_simtelfile.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,5 +42,24 @@ jobs:
       - name: Tests
         run: |
           pytest --cov=eventio --cov-report=xml
+
+      - name: Run examples
+        run: |
+          pip install -e '.[examples]'
+          cd examples
+          RESOURCES="../tests/resources/"
+          
+          # python iter_mc_events.py
+          python plot_events.py $RESOURCES/gamma_test.simtel.gz
+          python plot_light_on_ground.py -i $RESOURCES/3_gammas_reuse_5.dat
+          # python plot_light_on_ground_by_particle.py
+          # python plot_light_on_ground_rgb.py
+          python plot_mc_pe.py -i $RESOURCES/gamma_20deg_0deg_run103___cta-prod4-sst-astri_desert-2150m-Paranal-sst-astri.simtel.gz
+          python plot_production_3d.py -i $RESOURCES/3_gammas_reuse_5.dat
+          python profile_simtel.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
+          # python read_all_objects.py
+          python read_simtel_corsika_events.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
+          # python trigger_times.py 
+          python try_simtelfile.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
 
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,5 +81,5 @@ jobs:
           python profile_simtel.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
           # python read_all_objects.py
           python read_simtel_corsika_events.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
-          python trigger_times.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
+          python trigger_times.py --max-shower-events 1 $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz
           python try_simtelfile.py $RESOURCES/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ event:
 
     with eventio.IACTFile('eventio/resources/one_shower.dat') as f:
         for event in f:
-            print(event.header.total_energy)
+            print(event.header["total_energy"])
             print(event.photon_bunches[0]['photons'].sum())
 
 

--- a/examples/iter_mc_events.py
+++ b/examples/iter_mc_events.py
@@ -5,7 +5,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 parser = ArgumentParser()
-parser.add_argument('inputfile')
+parser.add_argument(
+    "inputfile", help="Example file: tests/resources/40k_pixels.simtel.zst"
+)
 
 args = parser.parse_args()
 

--- a/examples/plot_events.py
+++ b/examples/plot_events.py
@@ -12,7 +12,10 @@ from eventio.simtel import SimTelFile
 
 
 parser = ArgumentParser()
-parser.add_argument('inputfile')
+parser.add_argument(
+    "inputfile", help="Example file: tests/resources/gamma_test.simtel.gz"
+)
+parser.add_argument("--max-events", default=1)
 args = parser.parse_args()
 
 
@@ -48,19 +51,21 @@ def build_cam_geom(simtel_file, telescope_id):
                 pix_rotation = 30 * u.deg
 
     return CameraGeometry(
-        cam_id='CAM-{}'.format(telescope_id),
-        pix_id=np.arange(cam_data['n_pixels']),
-        pix_x=cam_data['pixel_x'] * u.m,
-        pix_y=cam_data['pixel_y'] * u.m,
-        pix_area=cam_data['pixel_area'] * u.m**2,
+        name="CAM-{}".format(telescope_id),
+        pix_id=np.arange(cam_data["n_pixels"]),
+        pix_x=cam_data["pixel_x"] * u.m,
+        pix_y=cam_data["pixel_y"] * u.m,
+        pix_area=cam_data["pixel_area"] * u.m**2,
         pix_type=pix_type,
-        cam_rotation=cam_data['cam_rot'] * u.rad,
+        cam_rotation=cam_data["cam_rot"] * u.rad,
         pix_rotation=pix_rotation,
     )
 
 
 with SimTelFile(args.inputfile) as f:
-    for array_event in f:
+    for i, array_event in enumerate(f):
+        if i == args.max_events:
+            break
         print('Event:', array_event['event_id'])
         for telescope_id, event in array_event['telescope_events'].items():
             print('Telescope:', telescope_id)

--- a/examples/plot_light_on_ground.py
+++ b/examples/plot_light_on_ground.py
@@ -1,19 +1,21 @@
 import matplotlib.pyplot as plt
-from pkg_resources import resource_filename
 from argparse import ArgumentParser
 
 from eventio import IACTFile
 
 parser = ArgumentParser()
-parser.add_argument('-i', '--inputfile', dest='inputfile')
+parser.add_argument(
+    "-i",
+    "--inputfile",
+    dest="inputfile",
+    help="Example file: tests/resources/3_gammas_reuse_5.dat",
+)
 parser.add_argument('-e', '--event', dest='event', type=int, default=0)
 parser.add_argument('-t', '--telescope', dest='telescope', type=int)
 
 
 def main():
     args = parser.parse_args()
-    if not args.inputfile:
-        args.inputfile = resource_filename('eventio', 'resources/one_shower.dat')
 
     with IACTFile(args.inputfile) as f:
 

--- a/examples/plot_light_on_ground_by_particle.py
+++ b/examples/plot_light_on_ground_by_particle.py
@@ -69,38 +69,38 @@ def main():
             )
         fig.colorbar(img, ax=ax)
 
-    particle_id = event.particles['particle_id'] // 1000
-    particle_ids = {
-        1: 'γ',
-        2: 'e⁺',
-        3: 'e⁻',
-        5: 'μ⁺',
-        6: 'μ⁻',
-        13: 'n',
-        14: 'p',
-        15: r'$\bar{p}$',
-    }
+    if event.particles is not None:
+        particle_id = event.particles['particle_id'] // 1000
+        particle_ids = {
+            1: 'γ',
+            2: 'e⁺',
+            3: 'e⁻',
+            5: 'μ⁺',
+            6: 'μ⁻',
+            13: 'n',
+            14: 'p',
+            15: r'$\bar{p}$',
+        }
 
-    cmap = ListedColormap([f'C{i}' for i in range(len(particle_ids))])
+        cmap = ListedColormap([f'C{i}' for i in range(len(particle_ids))])
 
-    for i, pid in enumerate(particle_ids.keys()):
-        particle_id[particle_id == pid] = i
+        for i, pid in enumerate(particle_ids.keys()):
+            particle_id[particle_id == pid] = i
 
-    scat = axs[-1].scatter(
-        event.particles['x'] / 100,
-        event.particles['y'] / 100,
-        c=particle_id,
-        zorder=10,
-        cmap=cmap,
-        vmin=-0.5, vmax=len(particle_ids) - 0.5,
-    )
-    axs[-1].set_title('Particles reacing obslevel')
-    axs[-1].set_xlim(-radius, radius)
-    axs[-1].set_ylim(-radius, radius)
-    bar = fig.colorbar(scat, ax=axs[5])
-    bar.set_ticks(np.arange(len(particle_ids)))
-    bar.set_ticklabels(list(particle_ids.values()))
-    bar.update_bruteforce(scat)
+        scat = axs[-1].scatter(
+            event.particles['x'] / 100,
+            event.particles['y'] / 100,
+            c=particle_id,
+            zorder=10,
+            cmap=cmap,
+            vmin=-0.5, vmax=len(particle_ids) - 0.5,
+        )
+        axs[-1].set_title('Particles reaching obslevel')
+        axs[-1].set_xlim(-radius, radius)
+        axs[-1].set_ylim(-radius, radius)
+        bar = fig.colorbar(scat, ax=axs[5])
+        bar.set_ticks(np.arange(len(particle_ids)))
+        bar.set_ticklabels(list(particle_ids.values()))
 
     fig.tight_layout()
     if args.output:

--- a/examples/plot_mc_pe.py
+++ b/examples/plot_mc_pe.py
@@ -1,8 +1,9 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from pkg_resources import resource_filename
 
 import astropy.units as u
+
+from argparse import ArgumentParser
 
 from ctapipe.instrument import CameraGeometry
 from ctapipe.visualization import CameraDisplay
@@ -11,28 +12,37 @@ from eventio import EventIOFile
 from eventio.simtel import CameraSettings
 from eventio.iact import PhotoElectrons, TelescopeData
 
-input_file = resource_filename(
-    'eventio',
-    'resources/gamma_20deg_0deg_run103___cta-prod4-sst-astri_desert-2150m-Paranal-sst-astri.simtel.gz'
+parser = ArgumentParser()
+parser.add_argument(
+    "-i",
+    "--inputfile",
+    dest="inputfile",
+    help="Example file: tests/resources/gamma_20deg_0deg_run103___cta-prod4-sst-astri_desert-2150m-Paranal-sst-astri.simtel.gz",
 )
+parser.add_argument("--max-events", default=1)
+
+args = parser.parse_args()
 
 
-with EventIOFile(input_file) as f:
+with EventIOFile(args.inputfile) as f:
     cameras = {}
+    event_index = 0
     for o in f:
+        if event_index == args.max_events:
+            break
         if isinstance(o, CameraSettings):
             cam_data = o.parse()
             pix_type = 'square'
             pix_rotation = 0 * u.deg
 
             cameras[o.telescope_id] = CameraGeometry(
-                cam_id='CAM-{}'.format(o.telescope_id),
-                pix_id=np.arange(cam_data['n_pixels']),
-                pix_x=cam_data['pixel_x'] * u.m,
-                pix_y=cam_data['pixel_y'] * u.m,
-                pix_area=cam_data['pixel_area'] * u.m**2,
+                name="CAM-{}".format(o.telescope_id),
+                pix_id=np.arange(cam_data["n_pixels"]),
+                pix_x=cam_data["pixel_x"] * u.m,
+                pix_y=cam_data["pixel_y"] * u.m,
+                pix_area=cam_data["pixel_area"] * u.m**2,
                 pix_type=pix_type,
-                cam_rotation=cam_data['cam_rot'] * u.rad,
+                cam_rotation=cam_data["cam_rot"] * u.rad,
                 pix_rotation=pix_rotation,
             )
 
@@ -41,8 +51,10 @@ with EventIOFile(input_file) as f:
                 if isinstance(subo, PhotoElectrons):
                     pe = subo.parse()
 
-                    plt.figure()
+                    fig = plt.figure()
                     cam = cameras[subo.telescope_id]
                     disp = CameraDisplay(cam)
                     disp.image = pe['photoelectrons']
                     plt.show()
+                    plt.close()
+            event_index += 1

--- a/examples/plot_photon_density_vs_r.py
+++ b/examples/plot_photon_density_vs_r.py
@@ -1,0 +1,117 @@
+import matplotlib.pyplot as plt
+from argparse import ArgumentParser
+import numpy as np
+import pandas as pd
+from matplotlib.colors import hsv_to_rgb
+
+from eventio import IACTFile
+
+parser = ArgumentParser()
+parser.add_argument('inputfile')
+parser.add_argument('-e', '--event', type=int, default=0)
+parser.add_argument('-t', '--telescope', type=int)
+parser.add_argument('-n', '--n-bins', type=int, default=500)
+parser.add_argument('-r', '--radius', type=float)
+parser.add_argument('-o', '--outputfile')
+
+
+def percentile(p):
+    def perc(data):
+        return np.percentile(data, p)
+    perc.__name__ = f'{p}%'
+    return perc
+
+
+def main():
+    args = parser.parse_args()
+
+    with IACTFile(args.inputfile) as f:
+        it = iter(f)
+        event = next(it)
+        for i in range(args.event):
+            event = next(it)
+
+        if args.telescope:
+            photons = [event.photon_bunches[args.telescope]]
+            positions = [f.telescope_positions[args.telescope]]
+        else:
+            photons = list(event.photon_bunches.values())
+            positions = f.telescope_positions
+
+        if args.radius is None:
+            args.radius = f.telescope_positions['r'][0] / 100
+
+        edges = np.linspace(-args.radius, args.radius, args.n_bins + 1)
+
+        hists = []
+        for pos, tel_photons in zip(positions, photons):
+            hist, _, _ = np.histogram2d(
+                (tel_photons['x'] + pos[0]) / 100,
+                (tel_photons['y'] + pos[1]) / 100,
+                edges,
+            )
+            hists.append(hist)
+        img = np.sum(hists, axis=0)
+
+        center = 0.5 * (edges[:-1] + edges[1:])
+        width = np.diff(edges)[0]
+        y, x = np.meshgrid(center, center)
+        r = np.sqrt(x**2 + y**2)
+
+        df = pd.DataFrame({
+            'r': r.ravel(),
+            'x': x.ravel(),
+            'y': y.ravel(),
+            'density': img.ravel() / width**2
+        })
+
+        n_bins = 100
+        r = np.linspace(0, args.radius * np.sqrt(2), n_bins + 1)
+        df['bin'] = np.digitize(df['r'], r)
+        width = np.diff(r)
+
+        binned = pd.DataFrame({
+            'r_min': r[:-1],
+            'r_max': r[1:],
+            'r_center': 0.5 * (r[:-1] + r[1:]),
+            'r_width': np.diff(r),
+        }, index=np.arange(1, n_bins + 1))
+
+        binned = binned.join(df.groupby('bin')['density'].agg(
+            ['median', percentile(5), percentile(16), percentile(84), percentile(95)]
+        ))
+
+        fig, ax = plt.subplots()
+
+        x = np.zeros(n_bins * 2)
+        x[0::2] = binned['r_min']
+        x[1::2] = binned['r_max']
+
+        ax.errorbar(binned.r_center, binned['median'], xerr=binned.r_width / 2, ls='', label='Median')
+
+        y_low = np.repeat(binned['16%'], 2)
+        y_high = np.repeat(binned['84%'], 2)
+        ax.fill_between(x, y_low, y_high, color=hsv_to_rgb((0.6, 0.32, 1.0)), label='68% containment', zorder=0)
+
+        y_low = np.repeat(binned['5%'], 2)
+        y_high = np.repeat(binned['95%'], 2)
+        ax.fill_between(x, y_low, y_high, color=hsv_to_rgb((0.6, 0.1, 1.0)), label='90% containment', zorder=-1)
+
+        ax.margins(0, 0)
+
+
+        ax.set_ylabel('Photons / m²')
+        ax.set_xlabel('Core distance / m')
+        ax.legend()
+
+        fig.tight_layout()
+
+        if args.outputfile:
+            fig.savefig(args.outputfile, dpi=300)
+        else:
+            plt.show()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/examples/plot_production_3d.py
+++ b/examples/plot_production_3d.py
@@ -1,20 +1,23 @@
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
-from pkg_resources import resource_filename
+
 from argparse import ArgumentParser
 
-import eventio
+from eventio import IACTFile
+
 
 parser = ArgumentParser()
-parser.add_argument('-i', '--inputfile', dest='inputfile')
+parser.add_argument(
+    "-i",
+    "--inputfile",
+    required=True,
+    dest="inputfile",
+    help="Example file: tests/resources/3_gammas_reuse_5.dat",
+)
 parser.add_argument('-e', '--event', dest='event', type=int, default=0)
 
 args = parser.parse_args()
 
-
-testfile = resource_filename('eventio', 'resources/3_gammas_reuse_5.dat')
-
-with eventio.IACTFile(args.inputfile or testfile) as f:
+with IACTFile(args.inputfile) as f:
     it = iter(f)
     event = next(it)
     for i in range(args.event):
@@ -23,7 +26,7 @@ with eventio.IACTFile(args.inputfile or testfile) as f:
     fig = plt.figure()
     ax = fig.add_axes([0, 0, 1, 1], projection='3d')
 
-    obslevel = event.header.observation_levels[0]
+    obslevel = event.header["observation_height"][0]
 
     for pos, b in zip(f.telescope_positions, event.photon_bunches.values()):
         cz = 1 - (b['cx']**2 + b['cy']**2)
@@ -39,4 +42,5 @@ with eventio.IACTFile(args.inputfile or testfile) as f:
     ax.set_xlabel('x / m')
     ax.set_ylabel('y / m')
     ax.set_zlabel('z / km')
-    fig.savefig('shower.png', dpi=300)
+
+plt.show()

--- a/examples/profile_simtel.py
+++ b/examples/profile_simtel.py
@@ -5,7 +5,10 @@ from eventio import SimTelFile
 from argparse import ArgumentParser
 
 parser = ArgumentParser()
-parser.add_argument('inputfile')
+parser.add_argument(
+    "inputfile",
+    help="Example file: tests/resources/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz",
+)
 parser.add_argument('-s', '--sort', default='cumtime')
 parser.add_argument('-l', '--limit', default=50, type=int)
 parser.add_argument('-t', '--telescopes')

--- a/examples/read_all_objects.py
+++ b/examples/read_all_objects.py
@@ -1,9 +1,16 @@
+from argparse import ArgumentParser
+
 from eventio import EventIOFile
 from eventio.search_utils import yield_all_objects_depth_first
 
-path = 'eventio/resources/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz'
+parser = ArgumentParser()
+parser.add_argument(
+    "inputfile",
+    help="Example file: tests/resource/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz",
+)
+args = parser.parse_args()
 
-with EventIOFile(path) as f:
+with EventIOFile(args.inputfile) as f:
     for o, level in yield_all_objects_depth_first(f):
         if hasattr(o, 'parse'):
             o.parse()

--- a/examples/read_all_objects.py
+++ b/examples/read_all_objects.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser
 
 from eventio import EventIOFile
 from eventio.search_utils import yield_all_objects_depth_first
+import textwrap
 
 parser = ArgumentParser()
 parser.add_argument(
@@ -12,5 +13,5 @@ args = parser.parse_args()
 
 with EventIOFile(args.inputfile) as f:
     for o, level in yield_all_objects_depth_first(f):
-        if hasattr(o, 'parse'):
-            o.parse()
+        if hasattr(o, 'parse') and not o.header.only_subobjects:
+            print(repr(o), "\n", textwrap.indent(str(o.parse()), "    "))

--- a/examples/read_simtel_corsika_events.py
+++ b/examples/read_simtel_corsika_events.py
@@ -1,8 +1,16 @@
+from argparse import ArgumentParser
+
 from eventio import EventIOFile
 from eventio.simtel import MCEvent, MCShower
 
+parser = ArgumentParser()
+parser.add_argument(
+    "inputfile",
+    help="Example file: tests/resources/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz",
+)
+args = parser.parse_args()
 
-with EventIOFile('eventio/resources/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz') as f:
+with EventIOFile(args.inputfile) as f:
     for eventio_object in f:
         if isinstance(eventio_object, MCShower):
             shower = eventio_object.parse()
@@ -13,4 +21,8 @@ with EventIOFile('eventio/resources/gamma_20deg_0deg_run102___cta-prod4-sst-1m_d
             event['xcore'] /= 100
             event['ycore'] /= 100
 
-            print('   event: {event}, core_x={xcore:6.2f} m, core_y={ycore:6.2f} m'.format(**event))
+            print(
+                "   event_id: {event_id}, core_x={xcore:6.2f} m, core_y={ycore:6.2f} m".format(
+                    **event
+                )
+            )

--- a/examples/trigger_times.py
+++ b/examples/trigger_times.py
@@ -14,6 +14,7 @@ parser.add_argument(
     help="Example file: tests/resources/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz",
 )
 parser.add_argument("--max-shower-events", type=int, default=0)
+parser.add_argument("--interactive", action="store_true")
 args = parser.parse_args()
 
 with SimTelFile(args.inputfile) as f:
@@ -68,7 +69,12 @@ with SimTelFile(args.inputfile) as f:
 
             d2.image = trig
 
-            input("Enter for next telecope event")
+            if args.interactive:
+                input("Enter for next telecope event")
+            else:
+                fig.savefig(
+                    f"simtel_trigger_times_event_{event["event_id"]}_tel_{t["header"]["telescope_id"]}.png"
+                )
 
         if i == args.max_shower_events - 1:
             parser.exit(

--- a/examples/trigger_times.py
+++ b/examples/trigger_times.py
@@ -6,57 +6,67 @@ import astropy.units as u
 import numpy as np
 import matplotlib.pyplot as plt
 
+from argparse import ArgumentParser
 
-
-f = SimTelFile('tests/resources/gamma_20deg_0deg_run103___cta-prod4-sst-astri_desert-2150m-Paranal-sst-astri.simtel.gz')
-cam = f.telescope_descriptions[1]['camera_settings']
-geom = CameraGeometry(
-    'astri',
-    np.arange(cam['n_pixels']),
-    cam['pixel_x'] * u.m,
-    cam['pixel_y'] * u.m,
-    cam['pixel_area']* u.m**2,
-    pix_type='rectangular',
+parser = ArgumentParser()
+parser.add_argument(
+    "inputfile",
+    help="Example file: tests/resource/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz",
 )
+args = parser.parse_args()
 
+with SimTelFile(args.inputfile) as f:
+    # f = SimTelFile('tests/resources/gamma_20deg_0deg_run103___cta-prod4-sst-astri_desert-2150m-Paranal-sst-astri.simtel.gz')
+    cam = f.telescope_descriptions[1]["camera_settings"]
+    geom = CameraGeometry(
+        "astri",
+        np.arange(cam["n_pixels"]),
+        cam["pixel_x"] * u.m,
+        cam["pixel_y"] * u.m,
+        cam["pixel_area"] * u.m**2,
+        pix_type="rectangular",
+    )
 
-it = iter(f)
+    it = iter(f)
 
-plt.ion()
+    plt.ion()
 
-fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))
 
-d1 = CameraDisplay(geom, ax=ax1)
-d2 = CameraDisplay(geom, ax=ax2)
+    d1 = CameraDisplay(geom, ax=ax1)
+    d2 = CameraDisplay(geom, ax=ax2)
 
-d1.add_colorbar(ax=ax1)
-d2.add_colorbar(ax=ax2)
-ax1.set_title('ADCSum')
-ax2.set_title('Pixel Trigger Times')
+    d1.add_colorbar(ax=ax1)
+    d2.add_colorbar(ax=ax2)
+    ax1.set_title("ADCSum")
+    ax2.set_title("Pixel Trigger Times")
 
-x = geom.pix_x.to_value(u.m)
-y = geom.pix_y.to_value(u.m)
-for ax in (ax1, ax2):
-    ax.set_xlim(1.01 * x.min(), 1.01 * x.max())
-    ax.set_ylim(1.01 * y.min(), 1.01 * y.max())
+    x = geom.pix_x.to_value(u.m)
+    y = geom.pix_y.to_value(u.m)
+    for ax in (ax1, ax2):
+        ax.set_xlim(1.01 * x.min(), 1.01 * x.max())
+        ax.set_ylim(1.01 * y.min(), 1.01 * y.max())
 
-cmap = plt.get_cmap('viridis')
-cmap.set_bad('gray')
-d2.cmap = cmap
+    cmap = plt.get_cmap("viridis")
+    cmap.set_bad("gray")
+    d2.cmap = cmap
 
-fig.show()
-fig.tight_layout()
+    fig.show()
+    fig.tight_layout()
 
+    for event in f:
+        for t in event["telescope_events"].values():
+            d1.image = t["adc_samples"][0, :, 0]
 
-for event in f:
-    for t in event['telescope_events'].values():
+            print(t["pixel_timing"].keys())
 
-        d1.image = t['adc_sums'][0]
+            trig = np.full(geom.n_pixels, np.nan)
 
-        trig = np.full(geom.n_pixels, np.nan)
-        trig[t['pixel_trigger_times']['pixel_ids']] = t['pixel_trigger_times']['trigger_times']
-        trig = np.ma.array(trig, mask=np.isnan(trig))
+            trig[t["pixel_timing"]["pixel_list"]] = t["pixel_timing"]["time"][
+                t["pixel_timing"]["pixel_list"]
+            ][:, 0]  # note: selecting only forst type
+            trig = np.ma.array(trig, mask=np.isnan(trig))
 
-        d2.image = trig
+            d2.image = trig
 
-        input('Enter for next telecope event')
+            input("Enter for next telecope event")

--- a/examples/trigger_times.py
+++ b/examples/trigger_times.py
@@ -73,7 +73,7 @@ with SimTelFile(args.inputfile) as f:
                 input("Enter for next telecope event")
             else:
                 fig.savefig(
-                    f"simtel_trigger_times_event_{event["event_id"]}_tel_{t["header"]["telescope_id"]}.png"
+                    f"simtel_trigger_times_event_{event['event_id']}_tel_{t['header']['telescope_id']}.png"
                 )
 
         if i == args.max_shower_events - 1:

--- a/examples/trigger_times.py
+++ b/examples/trigger_times.py
@@ -11,8 +11,9 @@ from argparse import ArgumentParser
 parser = ArgumentParser()
 parser.add_argument(
     "inputfile",
-    help="Example file: tests/resource/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz",
+    help="Example file: tests/resources/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz",
 )
+parser.add_argument("--max-shower-events", type=int, default=0)
 args = parser.parse_args()
 
 with SimTelFile(args.inputfile) as f:
@@ -54,19 +55,22 @@ with SimTelFile(args.inputfile) as f:
     fig.show()
     fig.tight_layout()
 
-    for event in f:
+    for i, event in enumerate(f):
         for t in event["telescope_events"].values():
             d1.image = t["adc_samples"][0, :, 0]
-
-            print(t["pixel_timing"].keys())
 
             trig = np.full(geom.n_pixels, np.nan)
 
             trig[t["pixel_timing"]["pixel_list"]] = t["pixel_timing"]["time"][
                 t["pixel_timing"]["pixel_list"]
-            ][:, 0]  # note: selecting only forst type
+            ][:, 0]  # note: selecting only first type
             trig = np.ma.array(trig, mask=np.isnan(trig))
 
             d2.image = trig
 
             input("Enter for next telecope event")
+
+        if i == args.max_shower_events - 1:
+            parser.exit(
+                status=0, message="Maximum number of selected shower events reached."
+            )

--- a/examples/try_simtelfile.py
+++ b/examples/try_simtelfile.py
@@ -4,7 +4,10 @@ from eventio.simtel.simtelfile import SimTelFile
 from argparse import ArgumentParser
 
 parser = ArgumentParser()
-parser.add_argument('inputfile')
+parser.add_argument(
+    "inputfile",
+    help="tests/resources/gamma_20deg_0deg_run102___cta-prod4-sst-1m_desert-2150m-Paranal-sst-1m.simtel.gz",
+)
 parser.add_argument('-p', '--print', action='store_true')
 
 args = parser.parse_args()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dynamic = ["version"]
 test = [
     "pytest",
 ]
-examples = ["astropy >=5.3,<7.0.0a0", "ctapipe", "matplotlib"]
+examples = ["astropy >=5.3,<8.0.0a0", "ctapipe~=0.24.0", "matplotlib"]
 dev = [
     "setuptools_scm",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "eventio"
 description = "Python read-only implementation of the EventIO file format"
 
-requires-python = '<3.13'
+requires-python = '>=3.10'
 dependencies = [
     'numpy >= 1.21',
     'corsikaio >= 0.3.3,<0.6.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "eventio"
 description = "Python read-only implementation of the EventIO file format"
 
-requires-python = '>=3.10'
+requires-python = '<3.13'
 dependencies = [
     'numpy >= 1.21',
     'corsikaio >= 0.3.3,<0.6.0',
@@ -44,6 +44,7 @@ dynamic = ["version"]
 test = [
     "pytest",
 ]
+examples = ["astropy >=5.3,<7.0.0a0", "ctapipe", "matplotlib"]
 dev = [
     "setuptools_scm",
 ]


### PR DESCRIPTION
Examples from the README and in general from the examples folder seem to be outdated since #131.

Here I attempted to fix all of them, but for some (commented out at the moment from the list in the CI job) I could not find a suitable test file (or maybe there are deeper changes to apply to those examples). For a couple of examples I added a max-events option due to resource file truncations.

In order to ease the user experience, and also for the CI to not worry about specific dependencies, I created anew extra called 'examples'.
I noticed that when using python 3.13 something is pulling numba > 0.56 (either astropy or ctapipe) and this makes the installation crash. I tried different numba versions, but in the end limiting python to 3.12 proved to be the more most stable solution.

P.S: there is no documentation for this package, so I do not know if it makes sense, but you couldadd jupytext and make the examples folder a [sphinx-gallery](https://sphinx-gallery.github.io/stable/index.html)