### PR TITLE
Add structuring of history information in SimTelFile

### DIFF
--- a/src/eventio/simtel/simtelfile.py
+++ b/src/eventio/simtel/simtelfile.py
@@ -26,6 +26,7 @@ from .objects import (
     DisabledPixels,
     DriveSettings,
     History,
+    HistoryCommandLine,
     HistoryMeta,
     ImageParameters,
     LaserCalibration,
@@ -91,6 +92,8 @@ class SimTelFile(EventIOFile):
         self.histograms = None
 
         self.history = []
+        self.cli_history = []
+        self.config_history = {}
         self.mc_run_headers = []
         self.corsika_inputcards = []
         self.atmospheric_profiles = []
@@ -238,8 +241,25 @@ class SimTelFile(EventIOFile):
 
 
         elif isinstance(o, History):
+            # 0 are global defaults, then one per telescope
+            tel = 0
+            self.config_history[0] = []
+
             for sub in o:
-                self.history.append(sub.parse())
+                timestamp, line = sub.parse()
+
+                # backwards compatibility, keep flat list
+                self.history.append((timestamp, line))
+
+                if isinstance(sub, HistoryCommandLine):
+                    self.cli_history.append((timestamp, line))
+                else:
+                    # magic line that indicates the start of a new telescope configuration
+                    # see io_history.c
+                    if line.startswith(b"# Telescope-specific configuration follows"):
+                        tel += 1
+                        self.config_history[tel] = []
+                    self.config_history[tel].append((timestamp, line))
 
         elif isinstance(o, HistoryMeta):
             if o.header.id == -1:

--- a/tests/simtel/test_simtelfile.py
+++ b/tests/simtel/test_simtelfile.py
@@ -279,6 +279,19 @@ def test_history_meta():
         assert len(f.telescope_meta) == 19
 
 
+def test_history():
+    with SimTelFile(history_meta_path) as f:
+        assert isinstance(f.cli_history, list)
+        assert isinstance(f.config_history, dict)
+        assert len(f.cli_history) == 1
+        # global defaults + one per tel
+        assert len(f.config_history) == 20
+        assert len(f.history) == len(f.cli_history) + sum(len(c) for c in f.config_history.values())
+
+        # the flat history should be identical to the structured history flattened
+        assert f.history == f.cli_history + [h for c in f.config_history.values() for h in c]
+
+
 def test_type_2033():
     with SimTelFile(pixel_monitoring_path) as f:
         e = next(iter(f))


### PR DESCRIPTION
Splitting the flat history list into cli history and config_history (global defaults and per telescope).