### PR TITLE
feat: add support by fsspec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "Cython", "numpy>=1.25", 'setuptools_scm[toml]>=8']
+requires = ["setuptools>=64", "Cython", "numpy>=1.25", 'setuptools_scm[toml]>=8', 'fsspec']
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "Cython", "numpy>=1.25", 'setuptools_scm[toml]>=8', 'fsspec']
+requires = ["setuptools>=64", "Cython", "numpy>=1.25", 'setuptools_scm[toml]>=8']
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -11,6 +11,7 @@ dependencies = [
     'numpy >= 1.21',
     'corsikaio >= 0.3.3,<0.7.0',
     'zstandard > 0.11.1', # memory leak in zstandard 0.11.1
+	'fsspec'
 ]
 
 authors = [

--- a/src/eventio/base.py
+++ b/src/eventio/base.py
@@ -61,7 +61,7 @@ class PipeWrapper:
 
 class EventIOFile:
 
-    def __init__(self, path, zcat=True):
+    def __init__(self, path, zcat=True, use_fsspec=False):
         log.info('Opening new file {}'.format(path))
         self.path = path
         self.read_process = None
@@ -94,16 +94,25 @@ class EventIOFile:
                     self._filehandle = gzip.open(fsspec.open(path, mode='rb').open())
             else:
                 log.info('Using gzip module')
-                self._filehandle = gzip.open(fsspec.open(path, mode='rb').open())
+                if use_fsspec:
+                    self._filehandle = fsspec.open(path, mode='rb', compression='gzip').open()
+                else:
+                    self._filehandle = gzip.open(path, mode='rb')
 
         elif is_zstd(path):
             log.info('Found zstd compressed file')
-            self._filehandle = zstd.ZstdDecompressor().stream_reader(fsspec.open(path, 'rb').open(), read_size=1024**2)
+            if use_fsspec:
+                self._filehandle = fsspec.open(path, mode='rb', compression='zstd').open()
+            else:
+                self._filehandle = zstd.ZstdDecompressor().stream_reader(open(path, 'rb'), read_size=1024**2)
             self.zstd = True
 
         else:
             log.info('Found uncompressed file')
-            self._filehandle = fsspec.open(path, mode='rb').open()
+            if use_fsspec:
+                self._filehandle = fsspec.open(path, mode='rb').open()
+            else:
+                self._filehandle = open(path, 'rb')
 
         self._next_header_pos = 0
 

--- a/src/eventio/base.py
+++ b/src/eventio/base.py
@@ -5,6 +5,7 @@ import struct
 import gzip
 import logging
 import subprocess as sp
+import fsspec
 import zstandard as zstd
 from typing import Any
 
@@ -90,19 +91,19 @@ class EventIOFile:
                 except Exception as e:
                     log.info(str(e))
                     log.warning('Falling back to gzip module')
-                    self._filehandle = gzip.open(path)
+                    self._filehandle = gzip.open(fsspec.open(path, mode='rb').open())
             else:
                 log.info('Using gzip module')
-                self._filehandle = gzip.open(path)
+                self._filehandle = gzip.open(fsspec.open(path, mode='rb').open())
 
         elif is_zstd(path):
             log.info('Found zstd compressed file')
-            self._filehandle = zstd.ZstdDecompressor().stream_reader(open(path, 'rb'), read_size=1024**2)
+            self._filehandle = zstd.ZstdDecompressor().stream_reader(fsspec.open(path, 'rb').open(), read_size=1024**2)
             self.zstd = True
 
         else:
             log.info('Found uncompressed file')
-            self._filehandle = open(path, mode='rb')
+            self._filehandle = fsspec.open(path, mode='rb').open()
 
         self._next_header_pos = 0
 

--- a/src/eventio/file_types.py
+++ b/src/eventio/file_types.py
@@ -1,4 +1,6 @@
 import gzip
+import fsspec
+
 try:
     import zstandard as zstd
 except ModuleNotFoundError:
@@ -15,7 +17,7 @@ GZIP_MARKER = b'\x1f\x8b'
 
 
 def _check_marker(path, marker):
-    with open(path, 'rb') as f:
+    with fsspec.open(path, 'rb') as f:
         marker_bytes = f.read(len(marker))
 
     if len(marker_bytes) < len(marker):
@@ -41,17 +43,18 @@ def is_eventio(path):
     Test if a file is a valid eventio file by checking if the sync marker is there.
     '''
     if is_gzip(path):
-        with gzip.open(path, 'rb') as f:
-            marker_bytes = f.read(SYNC_MARKER_SIZE)
+        with fsspec.open(path, 'rb') as f:
+            with gzip.GzipFile(fileobj=f) as gz:
+                marker_bytes = gz.read(SYNC_MARKER_SIZE)
     elif is_zstd(path):
         if zstd is None:
             raise IOError('You need the `zstandard` module to read zstd files')
-        with open(path, 'rb') as f:
+        with fsspec.open(path, 'rb') as f:
             cctx = zstd.ZstdDecompressor()
             with cctx.stream_reader(f) as stream:
                 marker_bytes = stream.read(SYNC_MARKER_SIZE)
     else:
-        with open(path, 'rb') as f:
+        with fsspec.open(path, 'rb') as f:
             marker_bytes = f.read(SYNC_MARKER_SIZE)
 
     little = marker_bytes == SYNC_MARKER_LITTLE_ENDIAN

--- a/src/eventio/iact/__init__.py
+++ b/src/eventio/iact/__init__.py
@@ -98,8 +98,8 @@ class IACTFile(EventIOFile):
       EventEnd
     '''
 
-    def __init__(self, path, zcat=True):
-        super().__init__(path, zcat=zcat)
+    def __init__(self, path, zcat=True, use_fsspec=False):
+        super().__init__(path, zcat=zcat, use_fsspec=use_fsspec)
 
         header_object = next(self)
         check_type(header_object, RunHeader)

--- a/src/eventio/simtel/simtelfile.py
+++ b/src/eventio/simtel/simtelfile.py
@@ -166,8 +166,9 @@ class SimTelFile:
         skip_calibration=False,
         allowed_telescopes=None,
         zcat=True,
+        use_fsspec=False,
     ):
-        self._file = EventIOFile(path, zcat=zcat)
+        self._file = EventIOFile(path, zcat=zcat, use_fsspec=use_fsspec)
         self.path = path
 
         self.skip_calibration = skip_calibration

--- a/tests/test_open_file.py
+++ b/tests/test_open_file.py
@@ -62,6 +62,17 @@ def test_types_gzip():
 
     assert types == [1200, 1212, 1201, 1202, 1203, 1204, 1209, 1210]
 
+def test_types_gzip_fsspec():
+    from pathlib import Path
+    test_file = Path('tests/resources/one_shower.dat.gz').resolve()
+    with eventio.EventIOFile(test_file, zcat=False, use_fsspec=True) as f:
+        types = [o.header.type for o in f]
+    assert types == [1200, 1212, 1201, 1202, 1203, 1204, 1209, 1210]
+
+    with eventio.EventIOFile(test_file.as_uri(),zcat=False, use_fsspec=True) as f:
+        types = [o.header.type for o in f]
+        assert types == [1200, 1212, 1201, 1202, 1203, 1204, 1209, 1210]
+
 
 def test_types_zcat():
     from eventio.base import PipeWrapper


### PR DESCRIPTION
I just implement a simple interface to use `fsspec` to open the path specfied in EventIOFile. I have tried to use it in xrootd protocol, and it works perfect fine.

My biggest worry about these changes would be the zcat mode, it seems it just using the pipe /read the local files.

@maxnoe , maybe you can give more suggestions for that, thanks!